### PR TITLE
Lineplot: Fix overlap of plot and data listings

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,4 +1,3 @@
-.*Rproj
 ^\.Rproj\.user$
 ^LICENSE$
 ^README\.Rmd$
@@ -8,3 +7,4 @@
 ^pkgdown$
 .lintr
 inst/validation/results/.gitempty
+^.*\.Rproj$

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: dv.explorer.parameter
 Type: Package
 Title: Parameter exploration modules
-Version: 0.0.6
+Version: 0.0.7
 Authors@R: c(
         person("Boehringer-Ingelheim Pharma GmbH & Co.KG", role = c("cph", "fnd")),
         person(given = "Luis", family = "Moris Fernandez", role = c("aut", "cre"), email = "luis.moris.fernandez@gmail.com"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# dv.explorer.parameter 0.0.7
+
+* Lineplot:
+    * Fix overlap of plot and data listings.
+
 # dv.explorer.parameter 0.0.6
 
 * Lineplot:

--- a/R/mod_lineplot.R
+++ b/R/mod_lineplot.R
@@ -829,7 +829,7 @@ lineplot_server <- function(id, # nolint cyclomatic
 
       # TODO(miguel): Candidate for shared util? Give visibility to this recurrent problem
       fix_brush_position_under_mm <- function(elem) {
-        shiny::div(style = "height:70vh;position:relative", shiny::div(elem))
+        shiny::div(style = "position:relative", shiny::div(elem))
       }
 
       fix_brush_position_under_mm(plot)


### PR DESCRIPTION
Fixes #10.

I've checked that:
# Hotfix checklist

- [X] Bumped minor version number on both DESCRIPTION and NEWS.md

- [X] Build passes pipeline checks

- [X] The new changes do not affect the API

- [X] The new changes do not affect the documentation (including screenshots)

- [X] The new changes do not impact the QC report