### PR TITLE
add roc css dependencies

### DIFF
--- a/R/mod_roc.R
+++ b/R/mod_roc.R
@@ -4212,17 +4212,6 @@ parse_ci <- function(str) {
   sort(unique(as.numeric(strsplit(str, ";", fixed = TRUE)[[1]])))
 }
 
-roc_dependencies <- function() {
-  htmltools::htmlDependency(
-    name = "dv.explorer.parameter",
-    version = "1.0",
-    package = "dv.explorer.parameter",
-    src = "assets",
-    stylesheet = "css/roc.css",
-    all_files = FALSE
-  )
-}
-
 # https://github.com/vegawidget/vegawidget/issues/217
 # https://github.com/vegawidget/vegawidget/issues/218
 # To fix this issue we will wrap the elements in a renderUI that will solve this problem

--- a/R/utils_html_dependencies.R
+++ b/R/utils_html_dependencies.R
@@ -1,4 +1,3 @@
-# handle dependency
 #' @keywords internal
 ebas_sel_css_dep <- function() {
   htmltools::htmlDependency(
@@ -37,8 +36,8 @@ roc_dependencies <- function() {
     name = "dv.explorer.parameter",
     version = "1.0",
     package = "dv.explorer.parameter",
-    src = "assets",
-    stylesheet = "css/bp.css",
+    src = system.file("assets", package = "dv.explorer.parameter", mustWork = TRUE),
+    stylesheet = "css/roc.css",
     all_files = FALSE
   )
 }

--- a/R/utils_html_dependencies.R
+++ b/R/utils_html_dependencies.R
@@ -34,8 +34,7 @@ screenshot_deps <- function() {
 roc_dependencies <- function() {
   htmltools::htmlDependency(
     name = "dv.explorer.parameter",
-    version = "1.0",
-    package = "dv.explorer.parameter",
+    version = "1.0",    
     src = system.file("assets", package = "dv.explorer.parameter", mustWork = TRUE),
     stylesheet = "css/roc.css",
     all_files = FALSE

--- a/R/utils_html_dependencies.R
+++ b/R/utils_html_dependencies.R
@@ -34,7 +34,7 @@ screenshot_deps <- function() {
 roc_dependencies <- function() {
   htmltools::htmlDependency(
     name = "dv.explorer.parameter",
-    version = "1.0",    
+    version = "1.0",
     src = system.file("assets", package = "dv.explorer.parameter", mustWork = TRUE),
     stylesheet = "css/roc.css",
     all_files = FALSE

--- a/inst/assets/css/roc.css
+++ b/inst/assets/css/roc.css
@@ -1,0 +1,8 @@
+.roc_menu_bar {
+    margin-bottom: 20px;
+}
+
+.table-condensed.roc_info_table {
+    margin-bottom: 5px;
+}
+

--- a/tests/testthat/test-lineplot_app.R
+++ b/tests/testthat/test-lineplot_app.R
@@ -244,7 +244,7 @@ test_that("default values are set", {
     default_par = c("PARAM22", "PARAM23"),
     default_val = "VALUE2",
     default_visit_var = "VISIT2",
-    default_visit_val = c(1, 9),
+    default_visit_val = list(VISIT2 = c(1, 9)),
     default_main_group = "CAT2",
     default_sub_group = "CAT2"
   )
@@ -265,7 +265,7 @@ test_that("default values are set", {
   expect_equal(input_values[[ID$INPUT$CENT]], srv_defaults[["default_centrality_function"]])
   expect_equal(input_values[[ID$INPUT$DISP]], srv_defaults[["default_dispersion_function"]])
   expect_equal(input_values[[ID$INPUT$VIS_COL]], srv_defaults[["default_visit_var"]])
-  expect_equal(input_values[[ID$INPUT$VIS]], as.character(srv_defaults[["default_visit_val"]]))
+  expect_equal(input_values[[ID$INPUT$VIS]], as.character(srv_defaults[["default_visit_val"]][["VISIT2"]]))
   expect_equal(input_values[[ID$INPUT$VAL]], srv_defaults[["default_val"]])
   expect_equal(input_values[[ID$INPUT$MGRP]], srv_defaults[["default_main_group"]])
   expect_equal(input_values[[ID$INPUT$SGRP]], srv_defaults[["default_sub_group"]])


### PR DESCRIPTION
Add missing css dependency to roc module

# Hotfix checklist

- [x] Bumped minor version number on both DESCRIPTION and NEWS.md

- [x] Build passes pipeline checks

- [x] The new changes do not affect the API

- [x] The new changes do not affect the documentation (including screenshots)

- [x] The new changes do not impact the QC report