### PR TITLE
Switch from switch2 2 switch2mod.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: dv.explorer.parameter
 Type: Package
 Title: Parameter exploration modules
-Version: 0.0.13
+Version: 0.0.14
 Authors@R: c(
         person("Boehringer-Ingelheim Pharma GmbH & Co.KG", role = c("cph", "fnd")),
         person(given = "Luis", family = "Moris Fernandez", role = c("aut", "cre"), email = "luis.moris.fernandez@gmail.com"),
@@ -13,7 +13,7 @@ Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.3.1
-Suggests: dv.manager (>= 1.0.9.129), jsonlite, rmarkdown, testthat (>=
+Suggests: dv.manager (>= 2.1.3), jsonlite, rmarkdown, testthat (>=
         3.0.0), shinytest2, devtools, vdiffr, rvest, stringr, knitr,
         safetyData, png, rsvg, withr
 Config/testthat/edition: 3
@@ -29,4 +29,4 @@ Date: Tue May 31 12:12:27 2022
 Branch: dev
 ParentCommit: 9edd5ae0b32a3c7afbcf7215187748f310087a8a
 VignetteBuilder: knitr
-Remotes: boehringer-ingelheim/dv.manager@v2.1.2
+Remotes: boehringer-ingelheim/dv.manager@v2.1.3

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -13,17 +13,17 @@ Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.3.1
-Suggests: dv.manager (>= 2.1.3), jsonlite, rmarkdown, testthat (>=
-        3.0.0), shinytest2, devtools, vdiffr, rvest, stringr, knitr,
+Suggests: jsonlite, rmarkdown, testthat (>= 3.0.0),
+        shinytest2, devtools, vdiffr, rvest, stringr, knitr,
         safetyData, png, rsvg, withr
 Config/testthat/edition: 3
 Config/testthat/parallel: false
-Imports: shiny (>= 1.7.1),dplyr (>= 1.0.7), broom (>= 0.7.9), ggplot2
+Imports: shiny (>= 1.7.1), dplyr (>= 1.0.7), broom (>= 0.7.9), ggplot2
         (>= 3.3.5), DT (>= 0.19), purrr (>= 0.3.4), tidyr (>= 1.1.4),
         digest, rlang, tibble, checkmate (>= 2.0.0), GGally,
         fontawesome, shinyvalidate, htmltools, RColorBrewer, scales,
         shinyWidgets, r2d3, stats, Hmisc, base64enc, viridisLite,
-        vegawidget, pROC, gt, utils, precrec, glue
+        vegawidget, pROC, gt, utils, precrec, glue, dv.manager (>= 2.1.3)
 Depends: R (>= 4.0)
 Date: Tue May 31 12:12:27 2022
 Branch: dev

--- a/R/mod_boxplot.R
+++ b/R/mod_boxplot.R
@@ -767,8 +767,7 @@ mod_boxplot <- function(module_id,
         on_sbj_click_fun <- function() NULL
       } else {
         on_sbj_click_fun <- function() {
-          receiver_label <- afmm[["module_names"]][[receiver_id]]
-          afmm[["utils"]][["switch2"]](receiver_label)
+          afmm[["utils"]][["switch2mod"]](receiver_id)
         }
       }
 

--- a/R/mod_lineplot.R
+++ b/R/mod_lineplot.R
@@ -1602,8 +1602,7 @@ mod_lineplot <- function(module_id,
 
       on_sbj_click_fun <- NULL
       if (!is.null(receiver_id)) {
-        receiver_label <- afmm[["module_names"]][[receiver_id]]
-        on_sbj_click_fun <- function() afmm[["utils"]][["switch2"]](receiver_label)
+        on_sbj_click_fun <- function() afmm[["utils"]][["switch2mod"]](receiver_id)
       }
 
       lineplot_server(

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -99,7 +99,7 @@ test_communication_with_papo <- function(mod, data, trigger_input_id) {
     filtered_dataset = datasets,
     module_output = function() list(),
     module_names = list(papo = "Papo"),
-    utils = list(switch2 = function(id) NULL),
+    utils = list(switch2mod = function(id) NULL),
     dataset_metadata = list(name = shiny::reactive("dummy_dataset_name"))
   )
 


### PR DESCRIPTION
Adapts two modules to the recent `dv.manager` deprecation of `afmm$switch2`.

I see a slight problem with this change: This module does not _depend_ on `dv.manager` (only _suggests_ its installation). So increasing the required `dv.manager` version does not force users to install `dv.manager>=2.1.3` (or any other version, for that matter). This shouldn't be a problem for new users of the ecosystem, but will generate an error for users of older versions of `dv.manager`. It's a corner case that we could ignore or maybe address through code, although I would argue that making `dv.manager` an `Import` would be a better way to go.