### PR TITLE
Sync shared code

### DIFF
--- a/inst/validation/specs.R
+++ b/inst/validation/specs.R
@@ -31,6 +31,9 @@ specs <- list(
     ",
     bookmark = "
     The application shall support bookmarking. Boxplot selection by click and double click are explicitly excluded.
+    ",
+    jumping_feature = "
+    The module can communicate subject values to other modules.
     "
 ),
 
@@ -99,6 +102,9 @@ lineplot_module = list(
     ",
     reference_values = "
     The chart optionally displays reference values as horizontal lines. Those are provided as separate columns of the visit-dependent dataset.
+    ",
+    jumping_feature = "
+    The module can communicate subject values to other modules.
     "
 ),
 

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -83,7 +83,7 @@ expect_r2d3_svg <- function(app, query_list) {
   })
 }
 
-# YT#VHef8421f23bae3b171c0b213512cc9d06#VH00000000000000000000000000000000#
+# YT#VH0bf15c0db690dfd3fac713f3c9b61f66#VH00000000000000000000000000000000#
 
 #' Test harness for communication with `dv.papo`.
 #'
@@ -91,7 +91,7 @@ expect_r2d3_svg <- function(app, query_list) {
 #' @param data Data matching the previous parameterization.
 #' @param trigger_input_id Fully namespaced input ID that, when set to a subject ID value,
 #'                         should make the module send `dv.papo` a message.
-test_communication_with_papo <- function(mod, data, trigger_input_id) {
+test_communication_with_papo <- function(mod, data, trigger_input_id, papo_spec_id, papo_spec_text) {
   datasets <- shiny::reactive(data)
 
   afmm <- list(
@@ -123,7 +123,8 @@ test_communication_with_papo <- function(mod, data, trigger_input_id) {
 
   app <- shiny::shinyApp(ui = app_ui, server = app_server)
 
-  testthat::test_that("module adheres to send_subject_id_to_papo protocol", {
+  testthat::test_that("module adheres to send_subject_id_to_papo protocol" |>
+    vdoc[["add_spec"]](papo_spec_text, papo_spec_id), { 
     app <- shinytest2::AppDriver$new(app, name = "test_send_subject_id_to_papo_protocol")
 
     app$wait_for_idle()

--- a/tests/testthat/test-boxplot-message_papo.R
+++ b/tests/testthat/test-boxplot-message_papo.R
@@ -1,7 +1,8 @@
-mod <- mod_boxplot_papo(
+mod <- mod_boxplot(
   module_id = "mod",
   bm_dataset_name = "bm",
   group_dataset_name = "sl",
+  receiver_id = "papo",
   subjid_var = "SUBJID",
   cat_var = "PARCAT",
   par_var = "PARAM",
@@ -12,4 +13,6 @@ mod <- mod_boxplot_papo(
 )
 data <- test_data()
 trigger_input_id <- "mod-BOTON"
-test_communication_with_papo(mod, data, trigger_input_id)
+test_communication_with_papo(mod, data, trigger_input_id,
+                             'specs$boxplot_module$jumping_feature',
+                             specs$boxplot_module$jumping_feature)

--- a/tests/testthat/test-boxplot-message_papo.R
+++ b/tests/testthat/test-boxplot-message_papo.R
@@ -14,5 +14,5 @@ mod <- mod_boxplot(
 data <- test_data()
 trigger_input_id <- "mod-BOTON"
 test_communication_with_papo(mod, data, trigger_input_id,
-                             'specs$boxplot_module$jumping_feature',
+                             "boxplot_module$jumping_feature",
                              specs$boxplot_module$jumping_feature)

--- a/tests/testthat/test-lineplot-message_papo.R
+++ b/tests/testthat/test-lineplot-message_papo.R
@@ -14,5 +14,5 @@ mod <- mod_lineplot(
 data <- test_data()
 trigger_input_id <- "mod-selected_subject"
 test_communication_with_papo(mod, data, trigger_input_id, 
-                             'specs$lineplot_module$jumping_feature',
+                             "lineplot_module$jumping_feature",
                              specs$lineplot_module$jumping_feature)

--- a/tests/testthat/test-lineplot-message_papo.R
+++ b/tests/testthat/test-lineplot-message_papo.R
@@ -13,4 +13,6 @@ mod <- mod_lineplot(
 )
 data <- test_data()
 trigger_input_id <- "mod-selected_subject"
-test_communication_with_papo(mod, data, trigger_input_id)
+test_communication_with_papo(mod, data, trigger_input_id, 
+                             'specs$lineplot_module$jumping_feature',
+                             specs$lineplot_module$jumping_feature)


### PR DESCRIPTION
This is a very minor update.
It just updates the "test communication with papo" shared snippet to the latest version available in our ecosystem.
That version defines a validation identifier for the test.
I've also taken the opportunity to move a test away from deprecated `mod_boxplot_papo`.