### PR TITLE
Hotfix/mapping multiple visit vars

### DIFF
--- a/R/map_afmm_auto.R
+++ b/R/map_afmm_auto.R
@@ -170,9 +170,13 @@ map_afmm_mod_lineplot_auto <- function(afmm, module_id, bm_dataset_name, group_d
             mapping_summary <- c(mapping_summary, paste0("(", ds_name, ") ", bm_dataset_name, "[[\"",
                 par_var, "\"]]"))
         }
-        if (is.character(ds[[bm_dataset_name]][[visit_vars]])) {
+
+        for (visit_var in visit_vars) {
+            if (is.character(ds[[bm_dataset_name]][[visit_var]])) {
             mapping_summary <- c(mapping_summary, paste0("(", ds_name, ") ", bm_dataset_name, "[[\"",
-                visit_vars, "\"]]"))
+                visit_var, "\"]]"))
+            }
+
         }
     }
     if (length(mapping_summary)) {
@@ -190,9 +194,13 @@ map_afmm_mod_lineplot_auto <- function(afmm, module_id, bm_dataset_name, group_d
             if (is.character(res[[bm_dataset_name]][[par_var]])) {
                 res[[bm_dataset_name]][[par_var]] <- as.factor(res[[bm_dataset_name]][[par_var]])
             }
-            if (is.character(res[[bm_dataset_name]][[visit_vars]])) {
-                res[[bm_dataset_name]][[visit_vars]] <- as.factor(res[[bm_dataset_name]][[visit_vars]])
+
+            for (visit_var in visit_vars) {
+            if (is.character(ds[[bm_dataset_name]][[visit_var]])) {
+                res[[bm_dataset_name]][[visit_var]] <- as.factor(res[[bm_dataset_name]][[visit_var]])
             }
+
+        }
             return(res)
         })
     }

--- a/R/map_afmm_auto.R
+++ b/R/map_afmm_auto.R
@@ -171,6 +171,7 @@ map_afmm_mod_lineplot_auto <- function(afmm, module_id, bm_dataset_name, group_d
                 par_var, "\"]]"))
         }
 
+        # MANUAL PATCH (S)
         for (visit_var in visit_vars) {
             if (is.character(ds[[bm_dataset_name]][[visit_var]])) {
             mapping_summary <- c(mapping_summary, paste0("(", ds_name, ") ", bm_dataset_name, "[[\"",
@@ -178,6 +179,7 @@ map_afmm_mod_lineplot_auto <- function(afmm, module_id, bm_dataset_name, group_d
             }
 
         }
+        # MANUAL PATCH (F)
     }
     if (length(mapping_summary)) {
         warning_message <- paste0("[mod_lineplot] This module will map the following dataset columns from `character` to `factor`:\n",
@@ -194,11 +196,13 @@ map_afmm_mod_lineplot_auto <- function(afmm, module_id, bm_dataset_name, group_d
             if (is.character(res[[bm_dataset_name]][[par_var]])) {
                 res[[bm_dataset_name]][[par_var]] <- as.factor(res[[bm_dataset_name]][[par_var]])
             }
-
+            
+            # MANUAL PATCH (S)
             for (visit_var in visit_vars) {
             if (is.character(ds[[bm_dataset_name]][[visit_var]])) {
                 res[[bm_dataset_name]][[visit_var]] <- as.factor(res[[bm_dataset_name]][[visit_var]])
             }
+            # MANUAL PATCH (F)
 
         }
             return(res)


### PR DESCRIPTION
hotfix for multiple visit_vars mapping (manual patch)

map generator does not cover multiple visit vars yet.
Therefore when accessing [[visit_vars]] and visit_vars has length > 1, the access fails, and the module crashes.
This commit include a manual patch to support that situation.

This should be merged into main before releasing v0.1.6