### PR TITLE
273717-enhance-lineplot-visibility-2 fixes

### DIFF
--- a/R/mod_lineplot.R
+++ b/R/mod_lineplot.R
@@ -264,6 +264,10 @@ lineplot_chart <- function(data, title = NULL, ref_line_data = NULL, log_project
       axis.text.y = ggplot2::element_text(size = STYLE$AXIS_TEXT_SIZE),
       strip.text.x = ggplot2::element_text(size = STYLE$STRIP_TEXT_SIZE),
       strip.text.y = ggplot2::element_text(size = STYLE$STRIP_TEXT_SIZE)
+    ) +
+    ggplot2::guides(
+      color = ggplot2::guide_legend(override.aes = list(alpha = 1)),
+      alpha = "none" # Excludes LINE_HIGHLIGHT_MASK column from the legend, because posit grammars are very intuitive
     )
 
   # Ensure that data for selected subjects are displayed using their existing color always, when grouping variables are used


### PR DESCRIPTION
This PR addresses issues raised during the PR of the target branch.
It also disentangles the highlighting of selected lines from the transparency feature.
It also restores the original position of some pieces of code (i.e. lines 200-208) and reintroduces deleted comments (e.g. line 246) that were written to justify some decisions that remain current and would be surprising to future maintainers if left uncommented.

Otherwise, the behavior of this branch is very similar to that of the target branch. In particular, it does not address the lack of highlighting of summary (mean, median) charts in the presence of whiskers.