### PR TITLE
[example] Add new parameter to mod_boxplot in the presence of the early error feedback wrapper

### DIFF
--- a/R/check_call_auto.R
+++ b/R/check_call_auto.R
@@ -4,8 +4,9 @@
 
 # dv.explorer.parameter::mod_boxplot
 check_mod_boxplot_auto <- function(afmm, datasets, module_id, bm_dataset_name, group_dataset_name, receiver_id,
-    cat_var, par_var, value_vars, visit_var, subjid_var, default_cat, default_par, default_visit, default_value,
-    default_main_group, default_sub_group, default_page_group, server_wrapper_func, warn, err) {
+    cat_var, par_var, value_vars, visit_var, subjid_var, anlfl_vars, default_cat, default_par, default_visit,
+    default_value, default_main_group, default_sub_group, default_page_group, server_wrapper_func, warn,
+    err) {
     OK <- logical(0)
     used_dataset_names <- new.env(parent = emptyenv())
     OK[["module_id"]] <- CM$check_module_id("module_id", module_id, warn, err)
@@ -39,6 +40,10 @@ check_mod_boxplot_auto <- function(afmm, datasets, module_id, bm_dataset_name, g
     flags <- list(subjid_var = TRUE, map_character_to_factor = TRUE)
     OK[["subjid_var"]] <- OK[["group_dataset_name"]] && CM$check_dataset_colum_name("subjid_var", subjid_var,
         subkind, flags, group_dataset_name, datasets[[group_dataset_name]], warn, err)
+    subkind <- list(kind = "or", options = list(list(kind = "character"), list(kind = "factor")))
+    flags <- list(optional = TRUE, ignore = TRUE)
+    OK[["anlfl_vars"]] <- OK[["bm_dataset_name"]] && CM$check_dataset_colum_name("anlfl_vars", anlfl_vars,
+        subkind, flags, bm_dataset_name, datasets[[bm_dataset_name]], warn, err)
     flags <- list(zero_or_more = TRUE, optional = TRUE)
     OK[["default_cat"]] <- OK[["cat_var"]] && CM$check_choice_from_col_contents("default_cat", default_cat,
         flags, "bm_dataset_name", datasets[[bm_dataset_name]], cat_var, warn, err)

--- a/R/map_afmm_auto.R
+++ b/R/map_afmm_auto.R
@@ -4,8 +4,8 @@
 
 # dv.explorer.parameter::mod_boxplot
 map_afmm_mod_boxplot_auto <- function(afmm, module_id, bm_dataset_name, group_dataset_name, receiver_id,
-    cat_var, par_var, value_vars, visit_var, subjid_var, default_cat, default_par, default_visit, default_value,
-    default_main_group, default_sub_group, default_page_group, server_wrapper_func) {
+    cat_var, par_var, value_vars, visit_var, subjid_var, anlfl_vars, default_cat, default_par, default_visit,
+    default_value, default_main_group, default_sub_group, default_page_group, server_wrapper_func) {
     res <- afmm
     mapping_summary <- character(0)
     for (ds_name in names(afmm[["data"]])) {

--- a/R/mod_boxplot.R
+++ b/R/mod_boxplot.R
@@ -248,6 +248,7 @@ boxplot_server <- function(id,
                            value_vars = "AVAL",
                            visit_var = "AVISIT",
                            subjid_var = "USUBJID",
+                           anlfl_vars = NULL,
                            default_cat = NULL,
                            default_par = NULL,
                            default_visit = NULL,
@@ -740,6 +741,7 @@ mod_boxplot <- function(module_id,
                         value_vars = "AVAL",
                         visit_var = "AVISIT",
                         subjid_var = "SUBJID",
+                        anlfl_vars = NULL,
                         default_cat = NULL,
                         default_par = NULL,
                         default_visit = NULL,
@@ -791,6 +793,7 @@ mod_boxplot_API_docs <- list(
   value_vars = "",
   visit_var = "",
   subjid_var = "",
+  anlfl_vars = "",
   default_cat = "",
   default_par = "",
   default_visit = "",
@@ -811,6 +814,7 @@ mod_boxplot_API_spec <- TC$group(
   value_vars = TC$col("bm_dataset_name", TC$numeric()) |> TC$flag("one_or_more"),
   visit_var = TC$col("bm_dataset_name", TC$or(TC$character(), TC$factor(), TC$numeric())) |> TC$flag("map_character_to_factor"),
   subjid_var = TC$col("group_dataset_name", TC$or(TC$character(), TC$factor())) |> TC$flag("subjid_var", "map_character_to_factor"),
+  anlfl_vars = TC$col("bm_dataset_name", TC$or(TC$character(), TC$factor())) |> TC$flag("optional", "ignore"),
   default_cat = TC$choice_from_col_contents("cat_var") |> TC$flag("zero_or_more", "optional"),
   default_par = TC$choice_from_col_contents("par_var") |> TC$flag("zero_or_more", "optional"),
   default_visit = TC$choice_from_col_contents("visit_var") |> TC$flag("optional"),
@@ -824,7 +828,7 @@ mod_boxplot_API_spec <- TC$group(
 
 check_mod_boxplot <- function(
     afmm, datasets, module_id, bm_dataset_name, group_dataset_name, receiver_id, cat_var, par_var, value_vars,
-    visit_var, subjid_var, default_cat, default_par, default_visit, default_value, default_main_group,
+    visit_var, subjid_var, anlfl_vars, default_cat, default_par, default_visit, default_value, default_main_group,
     default_sub_group, default_page_group, server_wrapper_func) {
   warn <- CM$container()
   err <- CM$container()
@@ -833,7 +837,7 @@ check_mod_boxplot <- function(
   # Something along the lines of OK <- CM$check_API(mod_corr_hm_API_spec, args = match.call(), warn, err)
   OK <- check_mod_boxplot_auto(
     afmm, datasets, module_id, bm_dataset_name, group_dataset_name, receiver_id, cat_var, par_var, value_vars,
-    visit_var, subjid_var, default_cat, default_par, default_visit, default_value, default_main_group,
+    visit_var, subjid_var, anlfl_vars, default_cat, default_par, default_visit, default_value, default_main_group,
     default_sub_group, default_page_group, server_wrapper_func, warn, err
   )
 


### PR DESCRIPTION
Hi, @typoumet!

Because the early error feedback procedure is still undocumented, here's an example of how to add a new parameter to `mod_boxplot`. The steps are:

1. Make the five changes you see on `R/mod_boxplot.R`.
2. Reload the module
3. Run `CM$generate_check_functions()` (which generates `R/check_call_autor.R`).
4. Run `CM$generate_map_afmm_functions()` (which generates `R/map_afmm_auto.R`).