### PR TITLE
Speedup eff flatten checks

### DIFF
--- a/.lintr.R
+++ b/.lintr.R
@@ -4,7 +4,6 @@ linters <- lintr::modify_defaults(
   , line_length_linter = NULL                 # we see how long lines are when we write them
   , indentation_linter = NULL
   , trailing_whitespace_linter = NULL
-  , cyclocomp_linter = NULL                   # prevents trivial amount of nesting and long but straightforward functions
   , object_name_linter = NULL                 # we have reasons to capitalize. nobody in our team CamelCase. shiny does
   , object_length_linter = NULL               # we don't type long var names just because
   , pipe_continuation_linter = NULL           # wickham being overly prescriptive

--- a/R/mod_boxplot.R
+++ b/R/mod_boxplot.R
@@ -1018,36 +1018,11 @@ check_mod_boxplot <- function(
 
   #ahwopu
   if (OK[["subjid_var"]] && OK[["cat_var"]] && OK[["par_var"]] && OK[["visit_var"]] && OK[["anlfl_vars"]]) {
-    if (!is.null(anlfl_vars)) {
-      # Check grouping values are unique for specified analysis flags
-      for (anlfl_var in anlfl_vars) {
-        CM_check_unique_sub_cat_par_vis(
-          datasets,
-          "bm_dataset_name",
-          bm_dataset_name,
-          subjid_var,
-          cat_var,
-          par_var,
-          visit_var,
-          anlfl_var,
-          warn = warn,
-          err = err
-        )
-      }
-    } else {
-      # Check grouping values are unique without subsetting on analysis flags
-      CM_check_unique_sub_cat_par_vis(
-        datasets,
-        "bm_dataset_name",
-        bm_dataset_name,
-        subjid_var,
-        cat_var,
-        par_var,
-        visit_var,
-        warn = warn,
-        err = err
-      )
-    }
+    check_unique_sub_cat_par_vis(
+      datasets, "bm_dataset_name", bm_dataset_name,
+      subjid_var, cat_var, par_var, visit_var, anlfl_vars,
+      warn = warn, err = err
+    )
   }
 
   res <- list(warnings = warn[["messages"]], errors = err[["messages"]])

--- a/R/mod_corr_hm.R
+++ b/R/mod_corr_hm.R
@@ -1022,24 +1022,11 @@ check_mod_corr_hm <- function(
   }
 
   if (OK[["subjid_var"]] && OK[["cat_var"]] && OK[["par_var"]] && OK[["visit_var"]] && OK[["anlfl_vars"]]) {
-
-    if (!is.null(anlfl_vars)) {
-      # Check grouping values are unique for specified analysis flags
-      for (anlfl_var in anlfl_vars) {
-        CM_check_unique_sub_cat_par_vis(
-          datasets, "bm_dataset_name", bm_dataset_name,
-          subjid_var, cat_var, par_var, visit_var, anlfl_var,
-          warn = warn, err = err
-        )
-      }
-    } else {
-      CM_check_unique_sub_cat_par_vis(
-        datasets, "bm_dataset_name", bm_dataset_name,
-        subjid_var, cat_var, par_var, visit_var,
-        warn = warn, err = err
-      )
-    }
-
+    check_unique_sub_cat_par_vis(
+      datasets, "bm_dataset_name", bm_dataset_name,
+      subjid_var, cat_var, par_var, visit_var, anlfl_vars,
+      warn = warn, err = err
+    )
   }
 
   res <- list(warnings = warn[["messages"]], errors = err[["messages"]])

--- a/R/mod_lineplot.R
+++ b/R/mod_lineplot.R
@@ -1893,27 +1893,13 @@ check_mod_lineplot <- function(
   # Checks that API spec does not (yet?) capture
   if (OK[["subjid_var"]] && OK[["cat_var"]] && OK[["par_var"]] &&
       OK[["visit_vars"]] && OK[["cdisc_visit_vars"]] && OK[["anlfl_vars"]]) {
-
     for (visit_var in c(visit_vars, cdisc_visit_vars)) {
-      if (!is.null(anlfl_vars)) {
-        # Check grouping values are unique for specified analysis flags
-        for (anlfl_var in anlfl_vars) {
-          CM_check_unique_sub_cat_par_vis(
-            datasets, "bm_dataset_name", bm_dataset_name,
-            subjid_var, cat_var, par_var, visit_var, anlfl = anlfl_var,
-            warn = warn, err = err
-          )
-        }
-      } else {
-        # Check grouping values are unique without subsetting on analysis flags
-        CM_check_unique_sub_cat_par_vis(
-          datasets, "bm_dataset_name", bm_dataset_name,
-          subjid_var, cat_var, par_var, visit_var,
-          warn = warn, err = err
-        )
-      }
+      check_unique_sub_cat_par_vis(
+        datasets, "bm_dataset_name", bm_dataset_name,
+        subjid_var, cat_var, par_var, visit_var, anlfl_vars,
+        warn = warn, err = err
+      )
     }
-
   }
 
   if (OK[["visit_vars"]] && OK[["cdisc_visit_vars"]]) {

--- a/R/mod_roc.R
+++ b/R/mod_roc.R
@@ -1169,16 +1169,16 @@ check_mod_roc <- function(
 
   # #ouhigo
   if (OK[["subjid_var"]] && OK[["pred_cat_var"]] && OK[["pred_par_var"]] && OK[["pred_visit_var"]]) {
-    CM_check_unique_sub_cat_par_vis(
+    check_unique_sub_cat_par_vis(
       datasets, "pred_dataset_name", pred_dataset_name,
-      subjid_var, pred_cat_var, pred_par_var, pred_visit_var, anlfl = NULL, warn = warn, err = err
+      subjid_var, pred_cat_var, pred_par_var, pred_visit_var, anlfl_vars = NULL, warn = warn, err = err
     )
   }
 
   if (OK[["subjid_var"]] && OK[["resp_cat_var"]] && OK[["resp_par_var"]] && OK[["resp_visit_var"]]) {
-    CM_check_unique_sub_cat_par_vis(
+    check_unique_sub_cat_par_vis(
       datasets, "resp_dataset_name", resp_dataset_name,
-      subjid_var, resp_cat_var, resp_par_var, resp_visit_var, anlfl = NULL,
+      subjid_var, resp_cat_var, resp_par_var, resp_visit_var, anlfl_vars = NULL,
       warn, err
     )
   }

--- a/R/mod_scatter.R
+++ b/R/mod_scatter.R
@@ -912,25 +912,11 @@ check_mod_scatterplot <- function(
 
   # Checks that API spec does not (yet?) capture
   if (OK[["subjid_var"]] && OK[["cat_var"]] && OK[["par_var"]] && OK[["visit_var"]] && OK[["anlfl_vars"]]) {
-
-    if (!is.null(anlfl_vars)) {
-      # Check grouping values are unique for specified analysis flags
-      for (anlfl_var in anlfl_vars) {
-        CM_check_unique_sub_cat_par_vis(
-          datasets, "bm_dataset_name", bm_dataset_name,
-          subjid_var, cat_var, par_var, visit_var, anlfl_var,
-          warn = warn, err = err
-        )
-      }
-    } else {
-      # Check grouping values are unique without subsetting on analysis flags
-      CM_check_unique_sub_cat_par_vis(
-        datasets, "bm_dataset_name", bm_dataset_name,
-        subjid_var, cat_var, par_var, visit_var,
-        warn = warn, err = err
-      )
-    }
-
+    check_unique_sub_cat_par_vis(
+      datasets, "bm_dataset_name", bm_dataset_name,
+      subjid_var, cat_var, par_var, visit_var, anlfl_vars,
+      warn = warn, err = err
+    )
   }
 
   res <- list(warnings = warn[["messages"]], errors = err[["messages"]])

--- a/R/mod_scatter_matrix.R
+++ b/R/mod_scatter_matrix.R
@@ -626,23 +626,11 @@ check_mod_scatterplotmatrix <- function(
 
   # Checks that API spec does not (yet?) capture
   if (OK[["subjid_var"]] && OK[["cat_var"]] && OK[["par_var"]] && OK[["visit_var"]] && OK[["anlfl_vars"]]) {
-
-    if (!is.null(anlfl_vars)) {
-      for (anlfl_var in anlfl_vars) {
-        CM_check_unique_sub_cat_par_vis(
-          datasets, "bm_dataset_name", bm_dataset_name,
-          subjid_var, cat_var, par_var, visit_var, anlfl_var,
-          warn = warn, err = err
-        )
-      }
-    } else {
-      CM_check_unique_sub_cat_par_vis(
-        datasets, "bm_dataset_name", bm_dataset_name,
-        subjid_var, cat_var, par_var, visit_var,
-        warn = warn, err = err
-      )
-    }
-
+    check_unique_sub_cat_par_vis(
+      datasets, "bm_dataset_name", bm_dataset_name,
+      subjid_var, cat_var, par_var, visit_var, anlfl_vars,
+      warn = warn, err = err
+    )
   }
 
   res <- list(warnings = warn[["messages"]], errors = err[["messages"]])

--- a/R/mod_wfphm.R
+++ b/R/mod_wfphm.R
@@ -2479,24 +2479,11 @@ check_mod_wfphm <- function(
 
   # #ahwopu
   if (OK[["subjid_var"]] && OK[["cat_var"]] && OK[["par_var"]] && OK[["visit_var"]] && OK[["anlfl_vars"]]) {
-
-    if (!is.null(anlfl_vars)) {
-      # Check grouping values are unique for specified analysis flags
-      for (anlfl_var in anlfl_vars) {
-        CM_check_unique_sub_cat_par_vis(
-          datasets, "bm_dataset_name", bm_dataset_name,
-          subjid_var, cat_var, par_var, visit_var, anlfl_var,
-          warn = warn, err = err
-        )
-      }
-    } else {
-      # Check grouping values are unique without subsetting on analysis flags
-      CM_check_unique_sub_cat_par_vis(
-        datasets, "bm_dataset_name", bm_dataset_name,
-        subjid_var, cat_var, par_var, visit_var,
-        warn = warn, err = err
-      )
-    }
+    check_unique_sub_cat_par_vis(
+      datasets, "bm_dataset_name", bm_dataset_name,
+      subjid_var, cat_var, par_var, visit_var, anlfl_vars,
+      warn = warn, err = err
+    )
   }
 
   res <- list(warnings = warn[["messages"]], errors = err[["messages"]])

--- a/R/utils-check.R
+++ b/R/utils-check.R
@@ -194,14 +194,14 @@ check_unique_sub_cat_par_vis <- function(datasets, ds_name, ds_value, sub, cat, 
   if (length(anlfl_vars) == 0) {
     # Check grouping values are unique without subsetting on analysis flags
     check_unique_sub_cat_par_vis_(
-      datasets, "bm_dataset_name", ds_name, sub, cat, par, vis, NULL,
+      datasets, ds_name, ds_value, sub, cat, par, vis, NULL,
       warn = warn, err = err
     )
   } else {
     # Check grouping values are unique for specified analysis flags
     for (anlfl_var in anlfl_vars) {
       check_unique_sub_cat_par_vis_(
-        datasets, "bm_dataset_name", ds_name, sub, cat, par, vis, anlfl_var,
+        datasets, ds_name, ds_value, sub, cat, par, vis, anlfl_var,
         warn = warn, err = err
       )
     }

--- a/R/utils-check.R
+++ b/R/utils-check.R
@@ -35,7 +35,7 @@ check_unique_sub_cat_par_vis_combinations <- function(dataset, sub_var, cat_var,
   )
 }
 
-CM_check_unique_sub_cat_par_vis <- function(datasets, ds_name, ds_value, sub, cat, par, vis, anlfl = NULL, warn, err) {
+check_unique_sub_cat_par_vis_ <- function(datasets, ds_name, ds_value, sub, cat, par, vis, anlfl, warn, err) {
     ok <- TRUE
     df_to_string <- function(df) {
       names(df) <- sprintf("[%s] ", names(df))
@@ -187,4 +187,25 @@ CM_check_unique_sub_cat_par_vis <- function(datasets, ds_name, ds_value, sub, ca
       })
 
     return(ok)
+}
+
+check_unique_sub_cat_par_vis <- function(datasets, ds_name, ds_value, sub, cat, par, vis, anlfl_vars, warn, err) {
+  if (length(anlfl_vars) == 0) {
+    # Check grouping values are unique without subsetting on analysis flags
+    check_unique_sub_cat_par_vis_(
+      datasets, "bm_dataset_name", bm_dataset_name,
+      subjid_var, cat_var, par_var, visit_var, anlfl_var = NULL,
+      warn = warn, err = err
+    )
+  }
+  else {
+    # Check grouping values are unique for specified analysis flags
+    for (anlfl_var in anlfl_vars) {
+      check_unique_sub_cat_par_vis_(
+        datasets, "bm_dataset_name", bm_dataset_name,
+        subjid_var, cat_var, par_var, visit_var, anlfl_var,
+        warn = warn, err = err
+      )
+    }
+  }
 }

--- a/R/utils-check.R
+++ b/R/utils-check.R
@@ -197,8 +197,7 @@ check_unique_sub_cat_par_vis <- function(datasets, ds_name, ds_value, sub, cat, 
       subjid_var, cat_var, par_var, visit_var, anlfl_var = NULL,
       warn = warn, err = err
     )
-  }
-  else {
+  } else {
     # Check grouping values are unique for specified analysis flags
     for (anlfl_var in anlfl_vars) {
       check_unique_sub_cat_par_vis_(

--- a/R/utils-check.R
+++ b/R/utils-check.R
@@ -136,6 +136,7 @@ check_unique_sub_cat_par_vis_ <- function(datasets, ds_name, ds_value, sub, cat,
             rep("Visit:", length(vis))
           )
 
+          supposedly_unique <- dataset[c(sub, cat, par, vis)]
           first_duplicates <- head(supposedly_unique[sub_cat_par_vis_combinations[["dup_mask"]], ], 5)
           names(first_duplicates) <- paste(prefixes, names(first_duplicates))
           dups <- df_to_string(first_duplicates)
@@ -193,16 +194,14 @@ check_unique_sub_cat_par_vis <- function(datasets, ds_name, ds_value, sub, cat, 
   if (length(anlfl_vars) == 0) {
     # Check grouping values are unique without subsetting on analysis flags
     check_unique_sub_cat_par_vis_(
-      datasets, "bm_dataset_name", bm_dataset_name,
-      subjid_var, cat_var, par_var, visit_var, anlfl_var = NULL,
+      datasets, "bm_dataset_name", ds_name, sub, cat, par, vis, NULL,
       warn = warn, err = err
     )
   } else {
     # Check grouping values are unique for specified analysis flags
     for (anlfl_var in anlfl_vars) {
       check_unique_sub_cat_par_vis_(
-        datasets, "bm_dataset_name", bm_dataset_name,
-        subjid_var, cat_var, par_var, visit_var, anlfl_var,
+        datasets, "bm_dataset_name", ds_name, sub, cat, par, vis, anlfl_var,
         warn = warn, err = err
       )
     }


### PR DESCRIPTION
Feature-branch-to-feature-branch PR, so omitting the checklist.

This PR:
- collapses some pre-existing code duplication (unrelated to the changes of the target branch)
- de-namespaces the `CM_check_unique_sub_cat_par_vis` function, as it sits outside of the `CM.R` snippet
- recovers a line that was accidentally during code reordering
